### PR TITLE
Update psrdada-python URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ This repository contains routines to fringestop DSA-110 visibilities on the meri
 
 ## Installation Instructions
 
-To use the PSRDADA tools in this install, you must also install PSRDADA, which can be installed according to [these instructions](http://psrdada.sourceforge.net/download.shtml) and psrdada-python, which can be installed from the [github repository](https://github.com/AA-ALERT/psrdada-python).
+To use the PSRDADA tools in this install, you must also install PSRDADA, which can be installed according to [these instructions](http://psrdada.sourceforge.net/download.shtml) and psrdada-python, which can be installed from the [github repository](https://github.com/TRASAL/psrdada-python).
 
 For psrdada-python to work with PSRDADA, PSRDADA must be installed using the -fPIC flag.  If you are using gnu-autotools to install, set the environment variable C_FLAGS before installing.
 


### PR DESCRIPTION
The Github organization hosting psrdada-python was renamed from AA-ALERT to TRASAL. I updated the README file to use the new URL. The old URL should also keep working for now.